### PR TITLE
Modify styling for MTG crosslink

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -104,12 +104,19 @@ ul.list-group > li.list-group-item.gray > span.badge > img {
 }
 
 /*
- * low-distraction links
+ * low-distraction
  */
-a.low-distraction {
-  color: #ddd;
+.low-distraction {
   font-size: .8em;
+}
+
+.low-distraction, a.low-distraction, a.low-distraction:active {
+  color: #bbb;
   text-decoration: none;
+}
+
+a.low-distraction:hover {
+  color: #666;
 }
 
 /*

--- a/index.html
+++ b/index.html
@@ -13,8 +13,13 @@
     <div class="container">
       <div class="col-md-12">
         <div class="page-header">
-          <h1>What's in Hearthstone Standard?</h1>
-          <a href="http://whatsinstandard.com/">(are you looking for what's in MTG Standard?)</a>
+          <h1>What's in Standard?</h1>
+          <div>
+            <span class="low-distraction">for</span>
+            <span>Hearthstone</span>
+            <span class="low-distraction"> / </span>
+            <a href="http://whatsinstandard.com/" class="low-distraction">Magic: The Gathering</a>
+          </div>
         </div>
       </div>
       <div class="col-md-5">


### PR DESCRIPTION
Modifies the styling on the MTG crosslink to match the styling from glacials/whatsinstandard#24.

This also changes the big `h1` from "What's in Hearthstone Standard?" to "What's in Standard?", which I think is fitting now that the game is listed right below the title, but let me know if you'd like it to stay as it is.
